### PR TITLE
feat: flexibility enhancement for groth16 fixed single output

### DIFF
--- a/py_zkp/groth16/poly_utils.py
+++ b/py_zkp/groth16/poly_utils.py
@@ -48,7 +48,7 @@ def div_polys(a, b):
 
 # Evaluate a polynomial at a point
 def eval_poly(poly, x):
-    return sum([poly[i] * x**i for i in range(len(poly))])
+    return sum([FR(poly[i]) * x**i for i in range(len(poly))])
 
 def mk_singleton(point_loc, height, total_pts):
     fac = FR(1)
@@ -66,7 +66,7 @@ def lagrange_interp(vec):
     for i in range(len(vec)):
         o = add_polys(o, mk_singleton(i + 1, FR(vec[i]), len(vec)))
     for i in range(len(vec)):
-        assert eval_poly(o, i + 1) == vec[i], \
+        assert eval_poly(o, i + 1) == FR(vec[i]), \
             (o, eval_poly(o, i + 1), i+1)
     return o
 

--- a/py_zkp/groth16/proving.py
+++ b/py_zkp/groth16/proving.py
@@ -1,7 +1,7 @@
 from py_ecc.fields import bn128_FQ as FQ
 from py_ecc import bn128
 
-from poly_utils import (
+from .poly_utils import (
     getNumWires,
     getNumGates
 )

--- a/py_zkp/groth16/qap_creator.py
+++ b/py_zkp/groth16/qap_creator.py
@@ -1,4 +1,4 @@
-from poly_utils import (
+from .poly_utils import (
     multiply_polys,
     add_polys,
     subtract_polys,

--- a/tests/test.py
+++ b/tests/test.py
@@ -81,7 +81,7 @@ def qeval(x):
   y = x**3
   z = y * x
   assert z == 81
-  return y + x + 5
+  return y + x + 5, z * x
 """
 
     code3 = """
@@ -106,11 +106,22 @@ def qeval(x):
   j = y * z
   assert n == z
   assert z == 81
-  return y + x + 5
+  return y + x + 5, n + 6
+"""
+
+    code6 = """
+def qeval(x):
+  y = x**3
+  z = y * x
+  n = y * x
+  j = y * z
+  assert n == z
+  assert z == 81
+  return
 """
     inputs = [3]
 
-    r, A, B, C  = code_to_r1cs_with_inputs(code5, inputs)
+    r, A, B, C  = code_to_r1cs_with_inputs(code6, inputs)
 
     print('r')
     print(r)
@@ -452,4 +463,4 @@ if __name__ == "__main__":
     # test_proving_and_verifying()
     # test_proving_and_verifying([0,1])
     # test_proving_and_verifying([0,2])
-    test_proving_and_verifying([0,1,2])
+    test_proving_and_verifying([0,1])


### PR DESCRIPTION
Now, the code can handle cases where there is no return value or multiple return values.

To facilitate separation of public and private values in the `r` vector, I've rearranged the positions of `outputs` and `inputs`. 

Returning a value now signifies creating a public outputs. Users can also select the private of inputs, and the public values in the `r` vector will be sorted by index.

If you don't want to make a public output, you can calculate a output without returning it.

Here are examples:
1.
> def qeval(x):
>     y = x**3
>     z = y * x
>     n = y * x
>     j = y * z
>     assert n == z
>     assert z == 81
>     return

2.
> def qeval(x):
>     y = x**3
>     z = y * x
>     return y + x + 5, z * x